### PR TITLE
Add composite multifile feature to galaxy

### DIFF
--- a/config/datatypes_conf.xml.sample
+++ b/config/datatypes_conf.xml.sample
@@ -1,6 +1,8 @@
 <?xml version="1.0"?>
 <datatypes>
   <registration converters_path="lib/galaxy/datatypes/converters" display_path="display_applications">
+    <datatype extension="multi" type="galaxy.datatypes.multifile:CompositeMultifile" display_in_upload="true"/>
+    <datatype extension="mtxt" type="galaxy.datatypes.multifile:MultiText" mimetype="text/html" display_in_upload="true"/>
     <datatype extension="ab1" type="galaxy.datatypes.binary:Ab1" mimetype="application/octet-stream" display_in_upload="true" description="A binary sequence file in 'ab1' format with a '.ab1' file extension.  You must manually select this 'File Format' when uploading the file." description_url="https://wiki.galaxyproject.org/Learn/Datatypes#Ab1"/>
     <datatype extension="afg" type="galaxy.datatypes.assembly:Amos" display_in_upload="false" />
     <datatype extension="arff" type="galaxy.datatypes.text:Arff" mimetype="text/plain" display_in_upload="True" />

--- a/config/tool_conf.xml.main
+++ b/config/tool_conf.xml.main
@@ -2,6 +2,7 @@
 <toolbox>
   <section id="getext" name="Get Data">
     <tool file="data_source/upload.xml" />
+    <tool file="data_source/multi_upload.xml" />
     <tool file="data_source/ucsc_tablebrowser.xml" />
     <tool file="data_source/ucsc_tablebrowser_archaea.xml" />
     <tool file="data_source/ebi_sra.xml" />

--- a/config/tool_conf.xml.sample
+++ b/config/tool_conf.xml.sample
@@ -2,6 +2,7 @@
 <toolbox>
   <section id="getext" name="Get Data">
     <tool file="data_source/upload.xml" />
+    <tool file="data_source/multi_upload.xml" />
     <tool file="data_source/ucsc_tablebrowser.xml" />
     <tool file="data_source/ucsc_tablebrowser_test.xml" />
     <tool file="data_source/ucsc_tablebrowser_archaea.xml" />

--- a/lib/galaxy/datatypes/multifile.py
+++ b/lib/galaxy/datatypes/multifile.py
@@ -1,0 +1,135 @@
+import data
+import logging
+import os
+from urllib import urlencode
+
+
+log = logging.getLogger(__name__)
+
+
+class CompositeMultifile(data.Data):
+    file_ext = 'multi'
+    composite_type = 'multifile'
+    blurb = 'Composite multifile'
+
+    def split(cls, input_datasets, subdir_generator_function, split_params):
+        """
+        Split the input composite dataset into individual files in task
+        directories.
+        """
+        if split_params is None:
+            return
+
+        # only one split_mode is accepted
+        if split_params['split_mode'] != 'from_composite':
+            raise Exception('Unsupported split mode %s. Use only from_composite as split mode.' % split_params['split_mode'])
+
+        # Test if datasets are eligible for multifile splitting (similar number of files in datasets)
+        amount = {}
+        filetypes = {}
+        for in_data in input_datasets:
+            try:
+                in_files = os.listdir(in_data.extra_files_path)
+            except OSError:
+                in_files = [in_data]
+                log.debug('Single file fed to splitting function. Faking a'
+                          ' composite file type by creating an appropriately'
+                          ' named softlink in an extra_files_path folder.')
+                os.makedirs(in_data.extra_files_path)
+                fn = os.path.basename(in_data.file_name)
+                os.symlink(in_data.file_name,
+                           os.path.join(in_data.extra_files_path, fn))
+                in_files = os.listdir(in_data.extra_files_path)
+
+            amount[len(in_files)] = 1
+            filetypes[in_data.file_name] = {}
+            for in_file in in_files:
+                if '.' not in in_file:
+                    filetypes[in_data.file_name][''] = 1
+                else:
+                    ext = in_file.split('.')[-1]
+                    filetypes[in_data.file_name][ext] = 1
+            assert len(filetypes[in_data.file_name].keys()) == 1, Exception('Different filetypes found in composite file list. Cannot split.')
+
+        assert len(amount.keys()) == 1, Exception('Different number of files are contained in the different dataset.')
+        # Split files
+        try:
+            # Take one file per composite dataset, and put it in a new task directory
+            for filenum in range(amount.keys()[0]):
+                part_dir = subdir_generator_function()
+                for in_data in input_datasets:
+                    members = os.listdir(in_data.extra_files_path)
+                    member = members[filenum]
+                    part_path = os.path.join(
+                        part_dir,
+                        os.path.basename(in_data.file_name))
+                    os.symlink(os.path.join(in_data.extra_files_path, member),
+                               part_path)
+        except Exception:
+            raise
+    split = classmethod(split)
+
+    def merge(split_files, output_dataset, output_filename, newnames=None):
+        """
+        Merges result files from task directories back into a composite
+        dataset's extra_files_path directory.
+        """
+        with open(output_filename, 'w') as fp:
+            fp.write('Composite dataset')
+        os.makedirs(output_dataset.extra_files_path)
+        try:
+            for i, in_file in enumerate(split_files):
+                if not newnames:
+                    filename, old_parentdir = os.path.split(in_file)[-1], os.path.split(os.path.split(in_file)[0])[-1]
+                    if 'task_' not in old_parentdir:
+                        raise Exception, 'Files named incorrectly and no new names supplied, cannot merge.'
+                else:
+                    filename = newnames[i]
+                os.rename(in_file, os.path.join(output_dataset.extra_files_path, filename))
+        except Exception:
+            raise
+
+    merge = staticmethod(merge)
+
+    def set_peek(self, dataset, is_multi_byte=True):
+        """Set the peek and blurb text"""
+        dataset.peek = '\n'.join(sorted(os.listdir(dataset.extra_files_path)))
+        dataset.blurb = self.blurb
+
+    def generate_primary_file(self, dataset=None):
+        if dataset.name.endswith('.nii.gz'):
+            base_name = dataset.name[:-7]
+        else:
+            base_name = dataset.name
+
+        flist = os.listdir(dataset.extra_files_path)
+        content = ['<html><body><p/>Files in {name}:<p/><ul>'.format(name=dataset.name)]
+        for i, fname in enumerate(flist):
+            sfname = os.path.split(fname)[-1]
+            display_name = sfname.replace('dataset', base_name)
+            content.append( '<li><a href="{filename}?{encoded_name}">{name}</a></li>'.format(
+                filename=sfname,
+                encoded_name=urlencode({"display_name": display_name}),
+                name=display_name))
+        content.append('</ul></body></html>')
+        return '\n'.join(content) + '\n'
+
+    def regenerate_primary_file(self, dataset):
+        content = self.generate_primary_file(dataset)
+        f = file(dataset.file_name, 'w')
+        f.write(content)
+        f.close()
+
+    def set_meta(self, dataset, overwrite=True, **kwd):
+        data.Data.set_meta(self, dataset, **kwd)
+        self.regenerate_primary_file(dataset)
+        return True
+
+    def get_mime(self):
+        """Returns the mime type of the datatype"""
+        return 'text/html'
+
+
+class MultiText(data.Text, CompositeMultifile):
+    file_ext = 'mtxt'
+    blurb = 'Composite multi text files'

--- a/lib/galaxy/jobs/splitters/multi.py
+++ b/lib/galaxy/jobs/splitters/multi.py
@@ -22,10 +22,8 @@ def do_split (job_wrapper):
         split_inputs = [x.strip() for x in split_inputs.split(",")]
 
     shared_inputs=parallel_settings.get("shared_inputs")
-    auto_shared_inputs = False
     if shared_inputs is None:
         shared_inputs = []
-        auto_shared_inputs = True
     else:
         shared_inputs = [x.strip() for x in shared_inputs.split(",")]
     illegal_inputs = [x for x in shared_inputs if x in split_inputs]
@@ -44,31 +42,20 @@ def do_split (job_wrapper):
 
     # For things like paired end alignment, we need two inputs to be split. Since all inputs to all
     # derived subtasks need to be correlated, allow only one input type to be split
-    # If shared_inputs are not specified, we assume all non-split inputs are shared inputs.
-    # For any input we must consider if each input is None. With optional arguments, a data input could be set to optional
     type_to_input_map = {}
     for input in parent_job.input_datasets:
-        if input.dataset is None:
-            if input.name in shared_inputs:
-                shared_inputs.remove(input.name)
-            else:
-                pass
+        if input.name in split_inputs:
+            type_to_input_map.setdefault(input.dataset.datatype, []).append(input.name)
+        elif input.name in shared_inputs:
+            pass # pass original file name
         else:
-            if input.name in split_inputs:
-                type_to_input_map.setdefault(input.dataset.datatype,  []).append(input.name)
-            elif input.name in shared_inputs:
-                pass # pass original file name
-            elif auto_shared_inputs:
-                shared_inputs.append(input.name)
-            else:
-                log_error = "The input '%s' does not define a method for implementing parallelism" % str(input.name)
-                log.exception(log_error)
-                raise Exception(log_error)
+            log_error = "The input '%s' does not define a method for implementing parallelism" % str(input.name)
+            log.exception(log_error)
+            raise Exception(log_error)
 
     if len(type_to_input_map) > 1:
-        log_error = "The multi splitter does not support splitting inputs of more than one type"
-        log.error(log_error)
-        raise Exception(log_error)
+        log_error = "The multi splitter does not support splitting inputs of more than one type, but migalaxy allows this anyway"
+        log.warning(log_error)
 
     # split the first one to build up the task directories
     input_datasets = []
@@ -131,15 +118,13 @@ def do_merge( job_wrapper,  task_wrappers):
     try:
         working_directory = job_wrapper.working_directory
         task_dirs = [os.path.join(working_directory, x) for x in os.listdir(working_directory) if x.startswith('task_')]
-        assert task_dirs, "Should be at least one sub-task!"
         # TODO: Output datasets can be very complex. This doesn't handle metadata files
         outputs = job_wrapper.get_output_hdas_and_fnames()
-        output_paths = job_wrapper.get_output_fnames()
         pickone_done = []
         task_dirs = [os.path.join(working_directory, x) for x in os.listdir(working_directory) if x.startswith('task_')]
         task_dirs.sort(key = lambda x: int(x.split('task_')[-1]))
-        for index, output in enumerate( outputs ):
-            output_file_name = str( output_paths[ index ] )  # Use false_path if set, else real path.
+        for output in outputs:
+            output_file_name = str(outputs[output][1])
             base_output_name = os.path.basename(output_file_name)
             if output in merge_outputs:
                 output_dataset = outputs[output][0]

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -569,6 +569,14 @@ class FileToolParameter( ToolParameter ):
         return None
 
 
+class MultiFileToolParameter(FileToolParameter):
+    """
+    Parameter to upload multiple files and merge them immediately.
+    """
+    def get_html_field(self, trans=None, value=None, other_values={}):
+        return form_builder.MultiFileField(self.name, ajax = self.ajax, value = value)
+
+
 class FTPFileToolParameter( ToolParameter ):
     """
     Parameter that takes a file uploaded via FTP as a value.
@@ -590,7 +598,7 @@ class FTPFileToolParameter( ToolParameter ):
         if trans is None or trans.user is None:
             user_ftp_dir = None
         else:
-            user_ftp_dir = trans.user_ftp_dir
+            user_ftp_dir = os.path.join(trans.app.config.ftp_upload_dir, trans.user.email)
         return form_builder.FTPFileField( self.name, user_ftp_dir, trans.app.config.ftp_upload_site, value=value )
 
     def from_html( self, value, trans=None, other_values={} ):
@@ -612,8 +620,14 @@ class FTPFileToolParameter( ToolParameter ):
         elif isinstance( value, unicode ) or isinstance( value, str ) or isinstance( value, list ):
             return value
 
-    def get_initial_value( self, trans, context, history=None ):
-        return None
+
+class FTPDirectoryToolParameter(FTPFileToolParameter):
+    def get_html_field(self, trans=None, value=None, other_values={}):
+        if trans is None or trans.user is None:
+            user_ftp_dir = None
+        else:
+            user_ftp_dir = os.path.join(trans.app.config.ftp_upload_dir, trans.user.email)
+        return form_builder.FTPDirectoryField(self.name, user_ftp_dir, trans.app.config.ftp_upload_site, value = value)
 
 
 class HiddenToolParameter( ToolParameter ):
@@ -2541,6 +2555,8 @@ parameter_types = dict(
     hidden_data=HiddenDataToolParameter,
     baseurl=BaseURLToolParameter,
     file=FileToolParameter,
+    ftpdirs=FTPDirectoryToolParameter,
+    multifile=MultiFileToolParameter,
     ftpfile=FTPFileToolParameter,
     data=DataToolParameter,
     data_collection=DataCollectionToolParameter,

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -1026,6 +1026,10 @@ def mkstemp_ln( src, prefix='mkstemp_ln_' ):
         except OSError, e:
             if e.errno == errno.EEXIST:
                 continue  # try again
+            elif e.errno == errno.EPERM:
+                # fallback to copying files (as of python 2.7.9)
+                shutil.copyfile(src, file)
+                return (os.path.abspath(file))
             raise
     raise IOError(errno.EEXIST, "No usable temporary file name found")
 

--- a/lib/galaxy/web/form_builder.py
+++ b/lib/galaxy/web/form_builder.py
@@ -159,6 +159,21 @@ class FileField(BaseField):
             ajax_text = ' galaxy-ajax-upload="true"'
         return unicodify( '<input type="file" name="%s%s"%s%s>' % ( prefix, self.name, ajax_text, value_text ) )
 
+
+class MultiFileField(FileField):
+    """
+    A multifile upload field.
+    """
+    def get_html( self, prefix="" ):
+        value_text = ""
+        if self.value:
+            value_text = ' value="%s"' % escape( str( self.value ),  quote=True )
+        ajax_text = ""
+        if self.ajax:
+            ajax_text = ' galaxy-ajax-upload="true"'
+        return '<input type="file" multiple name="%s%s"%s%s>' % ( prefix, self.name, ajax_text, value_text )
+
+
 class FTPFileField(BaseField):
     """
     An FTP file upload input.
@@ -207,7 +222,7 @@ class FTPFileField(BaseField):
         else:
             uploads = []
             for ( dirpath, dirnames, filenames ) in os.walk( self.dir ):
-                for filename in filenames:
+                for filename in sorted(filenames):
                     path = relpath( os.path.join( dirpath, filename ), self.dir )
                     statinfo = os.lstat( os.path.join( dirpath, filename ) )
                     uploads.append( dict( path=path,
@@ -221,6 +236,41 @@ class FTPFileField(BaseField):
         rval += FTPFileField.tfoot
         rval += '<div class="toolParamHelp">This Galaxy server allows you to upload files via FTP.  To upload some files, log in to the FTP server at <strong>%s</strong> using your Galaxy credentials (email address and password).</div>' % self.ftp_site
         return rval
+
+
+class FTPDirectoryField(FTPFileField):
+    """
+    An FTP directory upload input. To upload a directory full of same-datatype files and merge them into one dataset.
+    """
+    def get_html( self, prefix="" ):
+        rval = FTPFileField.thead
+        if self.dir is None:
+            rval += '<tr><td colspan="4"><em>Please <a href="%s">create</a> or <a href="%s">log in to</a> a Galaxy account to view files uploaded via FTP.</em></td></tr>' % ( url_for( controller='user', action='create', cntrller='user', referer=url_for( controller='root' ) ), url_for( controller='user', action='login', cntrller='user', referer=url_for( controller='root' ) ) )
+        elif not os.path.exists( self.dir ):
+            rval += '<tr><td colspan="4"><em>Your FTP upload directory contains no files.</em></td></tr>'
+        else:
+            uploads = []
+            directories = []
+            for ( dirpath, dirnames, filenames ) in os.walk( self.dir ):
+                # add directories to FTP field so we can upload a whole dir as a dataset
+                path = relpath( dirpath, self.dir )
+                if path != '.' and filenames:
+                    statinfo = os.lstat( os.path.join( dirpath ) )
+                    directories.append( dict( path=path,
+                                          size=nice_size( statinfo.st_size ),
+                                          ctime=time.strftime( "%m/%d/%Y %I:%M:%S %p", time.localtime( statinfo.st_ctime ) ), directory=True ) )
+                
+            # show directories first in the ftp field
+            for directory in directories:
+                rval += FTPFileField.trow % ( prefix, self.name, directory['path'], directory['path'], directory['size'], directory['ctime'] )
+            if not uploads:
+                rval += '<tr><td colspan="4"><em>Your FTP upload directory contains no files.</em></td></tr>'
+            for upload in uploads:
+                rval += FTPFileField.trow % ( prefix, self.name, upload['path'], upload['path'], upload['size'], upload['ctime'] )
+        rval += FTPFileField.tfoot
+        rval += '<div class="toolParamHelp">This Galaxy server allows you to upload files via FTP. To upload some files, log in to the FTP server at <strong>%s</strong> using your Galaxy credentials (email address and password).</div>' % self.ftp_site
+        return rval
+
 
 class HiddenField(BaseField):
     """

--- a/tools/data_source/multi_upload.xml
+++ b/tools/data_source/multi_upload.xml
@@ -1,0 +1,229 @@
+<?xml version="1.0"?>
+
+<tool name="Upload Multiple Files" id="multi_upload" version="1.1.4" workflow_compatible="false">
+  <description>
+    from your computer  
+  </description>
+  <action module="galaxy.tools.actions.upload" class="UploadToolAction"/>
+  <requirements>
+      <requirement type="package">samtools</requirement>
+  </requirements>
+  <command interpreter="python">
+      upload.py $GALAXY_ROOT_DIR $GALAXY_DATATYPES_CONF_FILE $paramfile
+    #set $outnum = 0
+    #while $varExists('output%i' % $outnum):
+        #set $output = $getVar('output%i' % $outnum)
+        #set $outnum += 1
+        #set $file_name = $output.file_name
+        ## FIXME: This is not future-proof for other uses of external_filename (other than for use by the library upload's "link data" feature)
+        #if $output.dataset.dataset.external_filename:
+            #set $file_name = "None"
+        #end if
+        ${output.dataset.dataset.id}:${output.files_path}:${file_name}
+    #end while
+  </command>
+  <inputs nginx_upload="true">
+    <param name="file_type" type="select" label="File Format" help="Which format? See help below">
+      <options from_parameter="tool.app.datatypes_registry.datatypes_with_merge" transform_lines="[ &quot;%s%s%s&quot; % ( line, self.separator, line ) for line in obj ]">
+        <column name="value" index="1"/>
+        <column name="name" index="0"/>
+        <filter type="sort_by" column="0"/>
+        <filter type="add_value" name="Auto-detect" value="auto" index="0"/>
+      </options>
+    </param>
+
+    <param name="async_datasets" type="hidden" value="None"/>
+    <upload_dataset name="files" title="Specify Files for Dataset" file_type_name="file_type" metadata_ref="files_metadata">
+        <param name="file_data" type="multifile" size="30" label="File" ajax-upload="true" help="TIP: Due to browser limitations, uploading files larger than 2GB is guaranteed to fail.  To upload large files, use the URL method (below) or FTP (if enabled by the site administrator).">
+        <validator type="expression" message="You will need to reselect the file you specified (%s)." substitute_value_in_message="True">not ( ( isinstance( value, unicode ) or isinstance( value, str ) ) and value != "" )</validator> <!-- use validator to post message to user about needing to reselect the file, since most browsers won't accept the value attribute for file inputs -->
+      </param>
+      <param name="url_paste" type="text" area="true" size="5x35" label="URL/Text" help="Here you may specify a list of URLs (one per line) or paste the contents of a file."/>
+      <param name="ftp_directories" type="ftpdirs" label="Whole directories containing files uploaded via FTP will be merged"/>
+      <param name="ftp_mergefiles" type="ftpfile" label="Files uploaded via FTP"/>
+      <!-- Swap the following parameter for the select one that follows to
+           enable the to_posix_lines option in the Web GUI. See Bitbucket
+           Pull Request 171 for more information. -->
+      <param name="uuid" type="hidden" required="False" />
+      <param name="to_posix_lines" type="hidden" value="Yes" />
+      <!--
+      <param name="to_posix_lines" type="select" display="checkboxes" multiple="True" label="Convert universal line endings to Posix line endings" help="Turn this option off if you upload a gzip, bz2 or zip archive which contains a binary file." value="Yes"> 
+        <option value="Yes" selected="true">Yes</option>
+      </param>
+      -->
+      <param name="space_to_tab" type="select" display="checkboxes" multiple="True" label="Convert spaces to tabs" help="Use this option if you are entering intervals by hand."> 
+        <option value="Yes">Yes</option>
+      </param>
+      <param name="NAME" type="hidden" help="Name for dataset in upload"></param>
+    </upload_dataset>
+    <param name="dbkey" type="genomebuild" label="Genome" />
+    <conditional name="files_metadata" title="Specify metadata" value_from="self:app.datatypes_registry.get_upload_metadata_params" value_ref="file_type" value_ref_in_group="False" />
+    <!-- <param name="other_dbkey" type="text" label="Or user-defined Genome" /> -->
+  </inputs>
+  <help>
+  
+**Auto-detect**
+
+The system will attempt to detect Axt, Fasta, Fastqsolexa, Gff, Gff3, Html, Lav, Maf, Tabular, Wiggle, Bed and Interval (Bed with headers) formats. If your file is not detected properly as one of the known formats, it most likely means that it has some format problems (e.g., different number of columns on different rows). You can still coerce the system to set your data to the format you think it should be.  You can also upload compressed files, which will automatically be decompressed. 
+
+-----
+
+**Ab1**
+
+A binary sequence file in 'ab1' format with a '.ab1' file extension.  You must manually select this 'File Format' when uploading the file.
+
+-----
+
+**Axt**
+
+blastz pairwise alignment format.  Each alignment block in an axt file contains three lines: a summary line and 2 sequence lines.  Blocks are separated from one another by blank lines.  The summary line contains chromosomal position and size information about the alignment. It consists of 9 required fields.
+
+-----
+
+**Bam**
+
+A binary file compressed in the BGZF format with a '.bam' file extension.
+
+-----
+
+**Bed**
+
+* Tab delimited format (tabular)
+* Does not require header line
+* Contains 3 required fields:
+
+  - chrom - The name of the chromosome (e.g. chr3, chrY, chr2_random) or contig (e.g. ctgY1).
+  - chromStart - The starting position of the feature in the chromosome or contig. The first base in a chromosome is numbered 0.
+  - chromEnd - The ending position of the feature in the chromosome or contig. The chromEnd base is not included in the display of the feature. For example, the first 100 bases of a chromosome are defined as chromStart=0, chromEnd=100, and span the bases numbered 0-99.
+
+* May contain 9 additional optional BED fields:
+
+  - name - Defines the name of the BED line. This label is displayed to the left of the BED line in the Genome Browser window when the track is open to full display mode or directly to the left of the item in pack mode.
+  - score - A score between 0 and 1000. If the track line useScore attribute is set to 1 for this annotation data set, the score value will determine the level of gray in which this feature is displayed (higher numbers = darker gray).
+  - strand - Defines the strand - either '+' or '-'.
+  - thickStart - The starting position at which the feature is drawn thickly (for example, the start codon in gene displays).
+  - thickEnd - The ending position at which the feature is drawn thickly (for example, the stop codon in gene displays).
+  - itemRgb - An RGB value of the form R,G,B (e.g. 255,0,0). If the track line itemRgb attribute is set to "On", this RBG value will determine the display color of the data contained in this BED line. NOTE: It is recommended that a simple color scheme (eight colors or less) be used with this attribute to avoid overwhelming the color resources of the Genome Browser and your Internet browser.
+  - blockCount - The number of blocks (exons) in the BED line.
+  - blockSizes - A comma-separated list of the block sizes. The number of items in this list should correspond to blockCount.
+  - blockStarts - A comma-separated list of block starts. All of the blockStart positions should be calculated relative to chromStart. The number of items in this list should correspond to blockCount.
+
+* Example::
+
+    chr22 1000 5000 cloneA 960 + 1000 5000 0 2 567,488, 0,3512
+    chr22 2000 6000 cloneB 900 - 2000 6000 0 2 433,399, 0,3601
+
+-----
+
+**Fasta**
+
+A sequence in FASTA format consists of a single-line description, followed by lines of sequence data.  The first character of the description line is a greater-than (">") symbol in the first column.  All lines should be shorter than 80 characters::
+
+    >sequence1
+    atgcgtttgcgtgc
+    gtcggtttcgttgc
+    >sequence2
+    tttcgtgcgtatag
+    tggcgcggtga
+
+-----
+
+**FastqSolexa**
+
+FastqSolexa is the Illumina (Solexa) variant of the Fastq format, which stores sequences and quality scores in a single file::
+
+    @seq1  
+    GACAGCTTGGTTTTTAGTGAGTTGTTCCTTTCTTT  
+    +seq1  
+    hhhhhhhhhhhhhhhhhhhhhhhhhhPW@hhhhhh  
+    @seq2  
+    GCAATGACGGCAGCAATAAACTCAACAGGTGCTGG  
+    +seq2  
+    hhhhhhhhhhhhhhYhhahhhhWhAhFhSIJGChO
+    
+Or:: 
+
+    @seq1
+    GAATTGATCAGGACATAGGACAACTGTAGGCACCAT
+    +seq1
+    40 40 40 40 35 40 40 40 25 40 40 26 40 9 33 11 40 35 17 40 40 33 40 7 9 15 3 22 15 30 11 17 9 4 9 4
+    @seq2
+    GAGTTCTCGTCGCCTGTAGGCACCATCAATCGTATG
+    +seq2
+    40 15 40 17 6 36 40 40 40 25 40 9 35 33 40 14 14 18 15 17 19 28 31 4 24 18 27 14 15 18 2 8 12 8 11 9
+    
+-----
+
+**Gff**
+
+GFF lines have nine required fields that must be tab-separated.
+
+-----
+
+**Gff3**
+
+The GFF3 format addresses the most common extensions to GFF, while preserving backward compatibility with previous formats.
+
+-----
+
+**Interval (Genomic Intervals)**
+
+- Tab delimited format (tabular)
+- File must start with definition line in the following format (columns may be in any order).::
+
+    #CHROM START END STRAND
+
+- CHROM - The name of the chromosome (e.g. chr3, chrY, chr2_random) or contig (e.g. ctgY1).
+- START - The starting position of the feature in the chromosome or contig. The first base in a chromosome is numbered 0.
+- END - The ending position of the feature in the chromosome or contig. The chromEnd base is not included in the display of the feature. For example, the first 100 bases of a chromosome are defined as chromStart=0, chromEnd=100, and span the bases numbered 0-99.
+- STRAND - Defines the strand - either '+' or '-'.
+
+- Example::
+
+    #CHROM START END   STRAND NAME COMMENT
+    chr1   10    100   +      exon myExon
+    chrX   1000  10050 -      gene myGene
+
+-----
+
+**Lav**
+
+Lav is the primary output format for BLASTZ.  The first line of a .lav file begins with #:lav..
+
+-----
+
+**MAF**
+
+TBA and multiz multiple alignment format.  The first line of a .maf file begins with ##maf. This word is followed by white-space-separated "variable=value" pairs. There should be no white space surrounding the "=".
+
+-----
+
+**Scf**
+
+A binary sequence file in 'scf' format with a '.scf' file extension.  You must manually select this 'File Format' when uploading the file.
+
+-----
+
+**Sff**
+
+A binary file in 'Standard Flowgram Format' with a '.sff' file extension.
+
+-----
+
+**Tabular (tab delimited)**
+
+Any data in tab delimited format (tabular)
+
+-----
+
+**Wig**
+
+The wiggle format is line-oriented.  Wiggle data is preceded by a track definition line, which adds a number of options for controlling the default display of this track.
+
+-----
+
+**Other text type**
+
+Any text file
+
+  </help>
+</tool>


### PR DESCRIPTION
This is to support a special type of composite dataset that can hold a collection of files.

:+1: The following is currently supported:
- Uploading through the new multi_upload tool (either via ftp or directly through the browser)
- Uploading through the rest api either to data libraries or histories (files need to be zipped and datatype needs to be set to a composite multifile type (or subtype))
- Producing a new multifile dataset as an output for a tool.

:-1: The following is yet to be done or supported:
- Uploading through the new upload tool is not yet supported (requires redesign/refactoring)
- Uploading to a data library through the web interface is not possible yet
- Unit tests were not writen :(
