### PR TITLE
Workaround for Datatype on Toolshed: Add PyDicom and NiBabel to list of required eggs for Galaxy

### DIFF
--- a/eggs.ini
+++ b/eggs.ini
@@ -9,7 +9,7 @@
 [general]
 repository = http://eggs.galaxyproject.org
 ; these eggs must be scrambled for your local environment
-no_auto = pbs_python
+no_auto = pbs_python pydicom nibabel
 
 [eggs:platform]
 bx_python = 0.7.2
@@ -77,6 +77,8 @@ wchartype = 0.1
 Whoosh = 2.4.1
 ; fluent_logger = 0.3.3
 raven = 3.1.8
+pydicom = 0.9.9
+nibabel = 1.3.0
 
 ; extra version information
 [tags]
@@ -91,6 +93,9 @@ pysam = _kanwei_b10f6e722e9a
 MySQL_python = mysql-5.1.41
 psycopg2 = postgresql-9.2.4
 pysqlite = sqlite-amalgamation-3_6_17
+pydicom = https://pypi.python.org/packages/source/p/pydicom/pydicom-0.9.9.tar.gz
+nibabel = https://pypi.python.org/packages/source/n/nibabel/nibabel-1.3.0.zip
 
 [dependencies]
 bx_python = numpy
+nibabel = numpy pydicom

--- a/lib/galaxy/eggs/scramble.py
+++ b/lib/galaxy/eggs/scramble.py
@@ -110,15 +110,15 @@ class ScrambleEgg( Egg ):
         if self.tag:
             urls.extend( map( lambda x: '.'.join( ( url_base + self.tag, x ) ), arctypes ) )
         self.source_path = self.fetch_one( urls )
-        if self.source_path is None:
+        if self.source_path is None and not self.sources:
             raise Exception( "%s(): Couldn't find a suitable source archive for %s %s from %s" % ( sys._getframe().f_code.co_name, self.name, self.version, self.url ) )
         for url in self.sources:
             if not urlparse.urlparse( url )[0]:
                 url = self.url + '/' + url.lstrip( '/' )
             urls = [ url ]
             urls.extend( map( lambda x: '.'.join( ( url, x ) ), arctypes ) ) # allows leaving off the extension and we'll try to find one
-            file = self.fetch_one( urls )
-            if file is None:
+            self.source_path = self.fetch_one( urls )
+            if self.source_path is None:
                 raise Exception( "%s(): Couldn't fetch extra source for %s, check path in %s.  URL(s) attempted output above." % ( sys._getframe().f_code.co_name, self.name, Crate.config_file, ) )
     def unpack_source( self ):
         unpack_dir = os.path.join( ScrambleEgg.build_dir, self.platform )


### PR DESCRIPTION
This is a workaround for not being able to define external library dependencies for custom datatypes installed via toolshed.
Not very nice, but necessary for Medical Imaging tools (MIG-USP group).
